### PR TITLE
fix: missing python build utilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM node:25-alpine as build-stage
+FROM node:25-alpine AS build-stage
 WORKDIR /app
+RUN apk add --no-cache python3 make g++ py3-setuptools
 RUN npm install -g pnpm
 COPY package.json .
 COPY pnpm-lock.yaml .


### PR DESCRIPTION
## Description
This PR fixes a bug in the Docker build process where the `sqlite3` package failed to compile on Alpine Linux. The build failed due to missing native build tools (`python3`, `make`, `g++`) and the absence of the `distutils` module in Python 3.12 (standard in recent Alpine images). 

The fix involves:
- Adding `python3`, `make`, and `g++` to the `build-stage` to support native module compilation.
- Adding `py3-setuptools` to provide the `distutils` module, which is required by older versions of `node-gyp` used by `sqlite3`.

## Related Issue
n/a

## Checklist

- [x] I have tested my changes locally
- [ ] I have updated the documentation if needed
- [x] This PR follows the project's coding style

## Additional Notes
The build now completes successfully on `node:25-alpine` based images. The `pnpm prune --prod` step, which previously failed, now correctly rebuilds native dependencies with the provided build tools.